### PR TITLE
Update path for MSCollectionViewCalendarLayout

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -2,7 +2,7 @@ platform :ios, '6.0'
 
 xcodeproj 'Example'
 
-pod 'MSCollectionViewCalendarLayout', :path => '../'
+pod 'MSCollectionViewCalendarLayout', :path => './../'
 
 pod 'RestKit', '~> 0.20'
 pod 'CupertinoYankee', '~> 0.1'


### PR DESCRIPTION
So that it works with latest cocoa pods.

Previously when running `pod install` after cloning the repo it errored with this message

```
Analyzing dependencies
Fetching podspec for `MSCollectionViewCalendarLayout` from `../`
[!] Unable to satisfy the following requirements:
- `MSCollectionViewCalendarLayout (from `../`)` required by `Podfile`
```

So I did the edit above and it worked. Strangely though if I change it back to just ../ it works second time. But if I re clone the repo it fails as before.
