### PR TITLE
Update CupertinoYankee

### DIFF
--- a/MSCollectionViewCalendarLayout.podspec
+++ b/MSCollectionViewCalendarLayout.podspec
@@ -12,5 +12,5 @@ Pod::Spec.new do |s|
   s.source_files = 'MSCollectionViewCalendarLayout/*.{h,m}'
   
   s.requires_arc = true
-  s.dependency 'CupertinoYankee', '~> 0.1'
+  s.dependency 'CupertinoYankee', '~> 1.0.1'
 end


### PR DESCRIPTION
Updating CupertinoYankee as setWeek was deprecated and the library updated to accommodate the changes.