### PR TITLE
configure App Transport Security for example application to work with iOS 9

### DIFF
--- a/Example/Example/Example-Info.plist
+++ b/Example/Example/Example-Info.plist
@@ -49,5 +49,10 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
The example as is does not work with iOS 9.
The following exception should be added to the info.plist file.
