### PR TITLE
Current Time Indicator displays on incorrect days.

### DIFF
--- a/MSCollectionViewCalendarLayout/MSCollectionViewCalendarLayout.m
+++ b/MSCollectionViewCalendarLayout/MSCollectionViewCalendarLayout.m
@@ -452,8 +452,8 @@ NSUInteger const MSCollectionMinBackgroundZ = 0.0;
         NSDateComponents *currentDay = [self dayForSection:section];
         NSDateComponents *currentTimeDateComponents = [self currentTimeDateComponents];
         // The current time is within this section's day
-		BOOL isSameDay = (currentTimeDateComponents.year == currentDay.year) && (currentTimeDateComponents.month == currentDay.month) && (currentTimeDateComponents.day == currentDay.day);
-		if (isSameDay && (currentTimeDateComponents.hour >= earliestHour) && (currentTimeDateComponents.hour < latestHour)) {
+        BOOL isSameDay = (currentTimeDateComponents.year == currentDay.year) && (currentTimeDateComponents.month == currentDay.month) && (currentTimeDateComponents.day == currentDay.day);
+        if (isSameDay && (currentTimeDateComponents.hour >= earliestHour) && (currentTimeDateComponents.hour < latestHour)) {
             
             // The y value of the current time
             CGFloat timeY = (calendarGridMinY + nearbyintf(((currentTimeDateComponents.hour - earliestHour) * self.hourHeight) + (currentTimeDateComponents.minute * self.minuteHeight)));

--- a/MSCollectionViewCalendarLayout/MSCollectionViewCalendarLayout.m
+++ b/MSCollectionViewCalendarLayout/MSCollectionViewCalendarLayout.m
@@ -452,7 +452,8 @@ NSUInteger const MSCollectionMinBackgroundZ = 0.0;
         NSDateComponents *currentDay = [self dayForSection:section];
         NSDateComponents *currentTimeDateComponents = [self currentTimeDateComponents];
         // The current time is within this section's day
-        if ((currentTimeDateComponents.day == currentDay.day) && (currentTimeDateComponents.hour >= earliestHour) && (currentTimeDateComponents.hour < latestHour)) {
+		BOOL isSameDay = (currentTimeDateComponents.year == currentDay.year) && (currentTimeDateComponents.month == currentDay.month) && (currentTimeDateComponents.day == currentDay.day);
+		if (isSameDay && (currentTimeDateComponents.hour >= earliestHour) && (currentTimeDateComponents.hour < latestHour)) {
             
             // The y value of the current time
             CGFloat timeY = (calendarGridMinY + nearbyintf(((currentTimeDateComponents.hour - earliestHour) * self.hourHeight) + (currentTimeDateComponents.minute * self.minuteHeight)));
@@ -1235,7 +1236,7 @@ NSUInteger const MSCollectionMinBackgroundZ = 0.0;
     }
     
     NSDate *date = [self.delegate currentTimeComponentsForCollectionView:self.collectionView layout:self];
-    NSDateComponents *currentTime = [[NSCalendar currentCalendar] components:(NSCalendarUnitDay | NSCalendarUnitHour | NSCalendarUnitMinute) fromDate:date];
+    NSDateComponents *currentTime = [[NSCalendar currentCalendar] components:(NSCalendarUnitYear | NSCalendarUnitMonth | NSCalendarUnitDay | NSCalendarUnitHour | NSCalendarUnitMinute) fromDate:date];
     
     [self.cachedCurrentDateComponents setObject:currentTime forKey:@(0)];
     return currentTime;


### PR DESCRIPTION
When using the Vertical Tile Section Layout, the current time indicator should only display when viewing today. Unfortunately, it also displays on all days that are the same day of the month as today (eg. today is June 15, the current time indicator also displays on January 15, February 15, etc).
